### PR TITLE
SHMACRO-11: Update the macro description to clarify its purpose

### DIFF
--- a/src/main/resources/Macros/ShowHideMacro.xml
+++ b/src/main/resources/Macros/ShowHideMacro.xml
@@ -455,10 +455,10 @@ Here is some hidden content that can become visible
       <contentType>Optional</contentType>
     </property>
     <property>
-      <defaultCategory>content</defaultCategory>
+      <defaultCategory>Content</defaultCategory>
     </property>
     <property>
-      <description>Show Hide Macro</description>
+      <description>XWiki macro for simple show/hide of a content with some animations</description>
     </property>
     <property>
       <id>showhide</id>

--- a/src/main/resources/Macros/ShowHideMacro.xml
+++ b/src/main/resources/Macros/ShowHideMacro.xml
@@ -458,7 +458,7 @@ Here is some hidden content that can become visible
       <defaultCategory>Content</defaultCategory>
     </property>
     <property>
-      <description>XWiki macro for simple show/hide of a content with some animations</description>
+      <description>Show/hide content with animations</description>
     </property>
     <property>
       <id>showhide</id>

--- a/src/main/resources/Macros/ShowHideMacro.xml
+++ b/src/main/resources/Macros/ShowHideMacro.xml
@@ -458,7 +458,7 @@ Here is some hidden content that can become visible
       <defaultCategory>Content</defaultCategory>
     </property>
     <property>
-      <description>Show/hide content with animations</description>
+      <description>Show/hide content with animations.</description>
     </property>
     <property>
       <id>showhide</id>


### PR DESCRIPTION
Related issue: https://github.com/xwikisas/xwiki-pro-macros/issues/403. Key changes:
* modified description  of the macro to better differentiate it from the pro show/hide if macros
* corrected the default category